### PR TITLE
Add NuGet badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # csvtrans
 _Tool for building translations from Google Sheet_
 
-[![Build Status](https://dev.azure.com/rickykaare/csvtrans/_apis/build/status/csvtrans-ci?branchName=master)](https://dev.azure.com/rickykaare/csvtrans/_build/latest?definitionId=2&branchName=master)
+[![Build Status](https://dev.azure.com/rickykaare/csvtrans/_apis/build/status/csvtrans-ci?branchName=master)](https://dev.azure.com/rickykaare/csvtrans/_build/latest?definitionId=2&branchName=master) [![NuGet](https://img.shields.io/nuget/dt/csvtrans.svg?style=flat-square)](http://www.nuget.org/packages/csvtrans) [![NuGet](https://img.shields.io/nuget/v/csvtrans.svg?style=flat-square)](http://www.nuget.org/packages/csvtrans)
 
 The idea behind the tool is to read translations from a Google Sheet and output them as string resources for iOS or Android. 
 


### PR DESCRIPTION
I originally wanted to build the ResW file support but after looking at code I realized I have completely forgotten **absolutely everything** about F# !! So my weekend goal will be to learn F#... again 

So here's a NuGet version and download count badge in the README file instead